### PR TITLE
Update 20190502110035-seed-script-up.sql

### DIFF
--- a/migrations/sqls/20190502110035-seed-script-up.sql
+++ b/migrations/sqls/20190502110035-seed-script-up.sql
@@ -2,28 +2,28 @@
 SET search_path TO lbstarter,public;
 
 insert into roles
-  (id, name, role_key, permissions)
+  (name, role_key, permissions)
   values
-  (1, 'super_admin', 1, '{ViewOwnUser,ViewAnyUser,ViewTenantUser,CreateAnyUser,CreateTenantUser,UpdateOwnUser,UpdateTenantUser,UpdateAnyUser,DeleteTenantUser,DeleteAnyUser,ViewTenant,CreateTenant,UpdateTenant,DeleteTenant,ViewRole,CreateRole,UpdateRole,DeleteRole,ViewAudit,CreateAudit,UpdateAudit,DeleteAudit}');
+  ('super_admin', 1, '{ViewOwnUser,ViewAnyUser,ViewTenantUser,CreateAnyUser,CreateTenantUser,UpdateOwnUser,UpdateTenantUser,UpdateAnyUser,DeleteTenantUser,DeleteAnyUser,ViewTenant,CreateTenant,UpdateTenant,DeleteTenant,ViewRole,CreateRole,UpdateRole,DeleteRole,ViewAudit,CreateAudit,UpdateAudit,DeleteAudit}');
 insert into roles
-  (id, name, role_key, permissions)
+  (name, role_key, permissions)
   values
-  (2, 'admin', 2, '{ViewOwnUser,ViewTenantUser,CreateTenantUser,UpdateOwnUser,UpdateTenantUser,DeleteTenantUser,ViewTenant,ViewRole}');
+  ('admin', 2, '{ViewOwnUser,ViewTenantUser,CreateTenantUser,UpdateOwnUser,UpdateTenantUser,DeleteTenantUser,ViewTenant,ViewRole}');
 insert into roles
-  (id, name, role_key, permissions)
+  (name, role_key, permissions)
   values
-  (3,'subscriber', 3, '{ViewOwnUser,ViewTenant,ViewRole}');
+  ('subscriber', 3, '{ViewOwnUser,ViewTenant,ViewRole}');
 
 insert into tenants
-  (id, name, type)
+  (name, type)
   values
-  (1, 'application', 'application');
+  ('application', 'application');
 
 /* Password - test123!@# */
 insert into users
-  (id, first_name, last_name, username, password, default_tenant)
+  (first_name, last_name, username, password, default_tenant)
   values
-  (1, 'Super', 'Admin', 'super_admin', '$2a$10$TOLMGK43MjbibS8Jap2RXeHl3.4sJcR3eFbms2dBll2LTMggSK9hG', 1);
+  ('Super', 'Admin', 'super_admin', '$2a$10$TOLMGK43MjbibS8Jap2RXeHl3.4sJcR3eFbms2dBll2LTMggSK9hG', 1);
 insert into user_tenants
   (user_id, tenant_id, role_id)
   values


### PR DESCRIPTION

## Description

Please remove ids from all your seeds inserts, since you are using sequences, if you insert with explicit ids, you are not using the sequence. Later when you call the post api it will through a pk uniqueness violations.

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested ?

If you try posting a role for the first few times (exactly 3 times) it will fail throwing a primary key violation. After the fix, post request works fine from first attempt. BTW I haven't test others, but I am assuming the same behavior will occur before the fix, since you are using sequence for tenants and users.
